### PR TITLE
feat: update sofmani to v1.28.1

### DIFF
--- a/Formula/sofmani.rb
+++ b/Formula/sofmani.rb
@@ -1,8 +1,8 @@
 class Sofmani < Formula
   desc "Installs software from a declerative config on any system"
   homepage "https://github.com/chenasraf/sofmani"
-  url "https://github.com/chenasraf/sofmani/archive/refs/tags/v1.28.0.tar.gz"
-  sha256 "f0eb75dde78f9e6a572252b07f1fcec9da84fafb1d8b5a50567bdd154544db1b"
+  url "https://github.com/chenasraf/sofmani/archive/refs/tags/v1.28.1.tar.gz"
+  sha256 "680bc165853988998b827f6d765413e73a0769ed9a98afefb53a6ac34a5ac48f"
   license "CC0-1.0"
 
   bottle do


### PR DESCRIPTION
## [1.28.1](https://github.com/chenasraf/sofmani/compare/v1.28.0...v1.28.1) (2026-04-12)


### Bug Fixes

* validate download filename for github release installer when it should run on current platform ([d31490d](https://github.com/chenasraf/sofmani/commit/d31490dbc9c1c496473f3eb1652899d182b29c66))
