### PR TITLE
feat: update wand to v1.5.0

### DIFF
--- a/Formula/wand.rb
+++ b/Formula/wand.rb
@@ -1,8 +1,8 @@
 class Wand < Formula
   desc "YAML-driven command runner with nested subcommands"
   homepage "https://github.com/chenasraf/wand"
-  url "https://github.com/chenasraf/wand/archive/refs/tags/v1.4.0.tar.gz"
-  sha256 "9b88b2b72d7a39c098111957d733f1b02365ee5195878e01c63f6a8d3d825798"
+  url "https://github.com/chenasraf/wand/archive/refs/tags/v1.5.0.tar.gz"
+  sha256 "92dfc91bf187cd7c8026675bdaa50093cac3ed488d9f902f6dc404f232fcf9d9"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
## [1.5.0](https://github.com/chenasraf/wand/compare/v1.4.0...v1.5.0) (2026-05-29)


### Features

* **cmd:** hide commands prefixed with _ from help ([6c55c25](https://github.com/chenasraf/wand/commit/6c55c25e966c55c740334b8d84e10195b3195561))
* **cmd:** pre and post command hooks ([aeb770d](https://github.com/chenasraf/wand/commit/aeb770d0189a9b5601d454e1a2bd845c03292f09))
