### PR TITLE
feat: update sofmani to v1.32.0

### DIFF
--- a/Formula/sofmani.rb
+++ b/Formula/sofmani.rb
@@ -1,8 +1,8 @@
 class Sofmani < Formula
   desc "Installs software from a declerative config on any system"
   homepage "https://github.com/chenasraf/sofmani"
-  url "https://github.com/chenasraf/sofmani/archive/refs/tags/v1.31.0.tar.gz"
-  sha256 "79d807fb7d864690b7bb84d1bf4967203b4bce65fb2d60f71721ad7a4556ea9f"
+  url "https://github.com/chenasraf/sofmani/archive/refs/tags/v1.32.0.tar.gz"
+  sha256 "7099cc86881da59ba66f1104c8338f77dc86ff1c1078a5225d0ba58bef36f082"
   license "CC0-1.0"
 
   bottle do


### PR DESCRIPTION
## [1.32.0](https://github.com/chenasraf/sofmani/compare/v1.31.0...v1.32.0) (2026-06-17)


### Features

* **brew:** trust tap when HOMEBREW_REQUIRE_TAP_TRUST is set ([1ba0990](https://github.com/chenasraf/sofmani/commit/1ba0990d69e7dec7c8838a40ef49ad13af78b84b))
